### PR TITLE
only dump one track to file when track is specified

### DIFF
--- a/src/linux/main_linux.c
+++ b/src/linux/main_linux.c
@@ -569,9 +569,9 @@ int main(int argc, char **argv) {
 
         mkdir(dumpwavdir, 0777);
 
-        const int last_song = track_specified ? track+1 : nsf->num_songs;
+        const int last_song = track_specified ? track : nsf->num_songs;
 
-        for (int i = track; i < last_song; i++) {
+        for (int i = track; i <= last_song; i++) {
             nsf->current_song = i;
 
             // 3 digits, WAV extension, slash, dot and NULL

--- a/src/linux/main_linux.c
+++ b/src/linux/main_linux.c
@@ -31,6 +31,10 @@ and nothing else. */
 #define true TRUE
 #endif
 
+#ifndef false
+#define false FALSE
+#endif
+
 /* This saves the trouble of passing our ONE nsf around the stack all day */
 static nsf_t *nsf = 0;
 
@@ -130,7 +134,7 @@ static void show_help(void) {
     printf("\nOptions:\n");
     printf("\t-h  \tHelp\n");
     printf("\t-v  \tVersion information\n");
-    printf("\n\t-t x\tStart playing track x (default: 1)\n");
+    printf("\n\t-t x\tPlay track x (default: 1)\n");
     printf("\t-s x\tPlay at x times the normal speed\n");
     printf("\t-f x\tUse x sampling rate (default: 44100)\n");
     printf("\t-B x\tUse sample size of x bits (default: 8)\n");
@@ -141,7 +145,7 @@ static void show_help(void) {
            "only)\n");
     printf("\t-i\tJust print file information and exit\n");
     printf("\t-x\tStart with channel x disabled (-123456)\n");
-    printf("\t-o x\tOutput WAV files to directory x\n\n");
+    printf("\t-o x\tOutput WAV file(s) to directory x\n\n");
     printf("\nPlease send bug reports to quadong@users.sf.net\n");
 
     exit(0);
@@ -460,6 +464,7 @@ int main(int argc, char **argv) {
     char *filename;
     char *dumpwavdir;
     int track = 1;
+    bool track_specified = false;
     int done = 0;
     int justdisplayinfo = 0;
     int dumpwav = 0;
@@ -493,6 +498,7 @@ int main(int argc, char **argv) {
             break;
         case 't':
             track = strtol(optarg, 0, 10);
+            track_specified = true;
             break;
         case 'f':
             freq = strtol(optarg, 0, 10);
@@ -563,7 +569,9 @@ int main(int argc, char **argv) {
 
         mkdir(dumpwavdir, 0777);
 
-        for (int i = track; i < nsf->num_songs; i++) {
+        const int last_song = track_specified ? track+1 : nsf->num_songs;
+
+        for (int i = track; i < last_song; i++) {
             nsf->current_song = i;
 
             // 3 digits, WAV extension, slash, dot and NULL


### PR DESCRIPTION
I need this for nsf support in [newdump](https://codeberg.org/Riedler/newdump). Well, *technically* I don't *need* it, but I avoid a whole lot of jank by just patching this.

fixes #1